### PR TITLE
Add the option to use relative paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ lazy_static = "1.4.0"
 
 [features]
 nightly = []
-relative-path = [ "nightly" ]
+relative-path = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ lazy_static = "1.4.0"
 
 [features]
 nightly = []
+relative-path = [ "nightly" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,6 @@ fn resolve_path(path: &str, parent_dir_path: Option<PathBuf>) -> PathBuf {
         )
     })
 }
-        panic!(
-            "An error occured while trying to resolve path: {:?}. Error: {}",
-            path, e
-        )
-    })
-}
 
 fn track_file(_path: &Path) {
     #[cfg(feature = "nightly")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,19 +25,22 @@ use regex::Regex;
 use std::fs::{canonicalize, read_to_string};
 use std::path::{Path, PathBuf};
 
-fn resolve_path(path: &str, relative: Option<&Path>) -> PathBuf {
-    if let Some(file) = relative {
-        let p = Path::new(path);
-        if p.has_root() {
-            canonicalize(p.iter().skip(1).collect::<PathBuf>())
-        }
-        else {
-            canonicalize(file.join(p))
+fn resolve_path(path: &str, parent_dir_path: Option<PathBuf>) -> PathBuf {
+    let mut path = PathBuf::from(path);
+
+    if let Some(p) = parent_dir_path {
+        if !path.is_absolute() {
+            path = p.join(path);
         }
     }
-    else {
-        canonicalize(path)
-    }.unwrap_or_else(|e| {
+
+    canonicalize(&path).unwrap_or_else(|e| {
+        panic!(
+            "An error occured while trying to resolve path: {:?}. Error: {}",
+            path, e
+        )
+    })
+}
         panic!(
             "An error occured while trying to resolve path: {:?}. Error: {}",
             path, e


### PR DESCRIPTION
Most of the include macros in the standard library, such as `include_str` and `include_bytes`, accept paths relative to the current directory rather than the workspace root. This change adds a feature flag, `relative-path`, which causes this crate to mirror the standard library's functionality. This makes it easier to migrate from using `include_str` to `include_shader`.